### PR TITLE
pom clean up and easing local hadoop download.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,33 @@ A simple way to test Hadoop and Hive using maven.
 Setup with Maven
 -----
 
-Run these commands initially or whenever your project is cleaned.
+By default, we're set to download a local copy of Hadoop when you first build Hive Test, or whenever the project is cleaned, just before running our test cases.
+
+You can force a redownload and installation of Hadoop by manually activating the download-hadoop profile
+
+    mvn --activate-profiles download-hadoop test
+
+You can also perform the download and extraction process independent of testing.
 
 Download Hadoop (into the maven target directory)
 
-    mvn wagon:download-single
+    mvn --activate-profiles download-hadoop wagon:download-single
 
 Extract Hadoop  (into the maven target directory)
 
-    mvn exec:exec
+    mvn --activate-profiles download-hadoop exec:exec
 
 Alternative
 -----
 
-* hadoop 0.20.X in your path ie /usr/bin/hadoop
+We'll skip attempting to download and use a local copy of Hadoop if any of the following are true
+
 * set your HADOOP_HOME environment variable to a hadoop distribution
-* hadoop tar extracted to  $home/hadoop/hadoop-0.20.2-local
+* hadoop tar extracted to  $home/hadoop/hadoop-0.20.2_local
+
+Hive Test will work so long as you have Hadoop 0.20.X in your path, i.e. /usr/bin/hadoop. In this case, you'll want to deactivate the hadoop download.
+
+    mvn --activate-profiles -download-hadoop test
 
 Usage
 -----

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
   <packaging>jar</packaging>
 	
   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <dependencies>
     <dependency>
@@ -187,45 +188,6 @@
   <build>
     <pluginManagement>
       <plugins>
-
-        <plugin>
-          <configuration>
-            <serverId>apache-main</serverId>
-            <url>http://www.apache.org/dist/hadoop/common/hadoop-0.20.2</url>
-            <fromFile>hadoop-0.20.2.tar.gz</fromFile>
-            <toDir>${project.build.directory}/hadoop</toDir>
-          </configuration>
-                                      
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>wagon-maven-plugin</artifactId>
-          <version>1.0-beta-3</version>
-          <executions>
-            <execution>
-              <id>download-hadoop</id>
-              <phase>pre-integration-test</phase>
-              <goals>
-                <goal>download-single</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>exec-maven-plugin</artifactId>
-          <version>1.2.1</version>
-          <configuration>
-            <executable>tar</executable>
-            <arguments>
-              <argument>-xf</argument>
-              <argument>${project.build.directory}/hadoop/hadoop-0.20.2.tar.gz</argument>
-              <argument>-C</argument>
-              <argument>${project.build.directory}</argument>
-            </arguments>
-          </configuration>
-        </plugin>
-
-
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-eclipse-plugin</artifactId>
@@ -262,4 +224,94 @@
     </repository>
 
   </repositories>
+  <profiles>
+    <profile>
+      <id>hadoop-in-target</id>
+      <activation>
+        <file>
+          <exists>${basedir}/target/hadoop-0.20.2</exists>
+        </file>
+      </activation>
+      <properties>
+        <hadoop_available>already_downloaded</hadoop_available>
+      </properties>
+    </profile>
+    <profile>
+      <id>hadoop-installed-in-home-dir</id>
+      <activation>
+        <file>
+          <exists>${user.home}/hadoop/hadoop-0.20.2_local</exists>
+        </file>
+      </activation>
+      <properties>
+        <hadoop_available>local_install</hadoop_available>
+      </properties>
+    </profile>
+    <profile>
+      <id>hadoop-home-defined</id>
+      <activation>
+        <property>
+          <name>env.HADOOP_HOME</name>
+        </property>
+      </activation>
+      <properties>
+        <hadoop_available>external_defined</hadoop_available>
+      </properties>
+    </profile>
+    <profile>
+      <id>download-hadoop</id>
+      <activation>
+        <!-- If any of the above profiles activates, we won't. -->
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <configuration>
+              <serverId>apache-main</serverId>
+              <url>http://archive.apache.org/dist/hadoop/common/hadoop-0.20.2</url>
+              <fromFile>hadoop-0.20.2.tar.gz</fromFile>
+              <toDir>${project.build.directory}/hadoop</toDir>
+            </configuration>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>wagon-maven-plugin</artifactId>
+            <version>1.0-beta-3</version>
+            <executions>
+              <execution>
+                <id>download-hadoop</id>
+                <phase>generate-test-resources</phase>
+                <goals>
+                  <goal>download-single</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+  
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.2.1</version>
+            <configuration>
+              <executable>tar</executable>
+              <arguments>
+                <argument>-xf</argument>
+                <argument>${project.build.directory}/hadoop/hadoop-0.20.2.tar.gz</argument>
+                <argument>-C</argument>
+                <argument>${project.build.directory}</argument>
+              </arguments>
+            </configuration>
+            <executions>
+              <execution>
+                <id>extract-hadoop</id>
+                <phase>process-test-resources</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
- Sets source encoding to UTF-8
- Updates typo in README for path checked withing user's home directory for local Hadoop
- Updates hadoop 0.20.2 download to archive.apache
- Adds a profile to handle the download and extraction of hadoop before tests
- Auto activates said profile when easy flags of a Hadoop install aren't present
- Updates README to reflect changes to profile

This update allows for a clean run of `mvn install` on a clean system that doesn't have Hadoop. You can walk through the testing for Hadoop by setting appropriate system conditions and using `mvn help:active-profiles`.
- On new checkout on clean system, should show "download-hadoop" as active
- If ${HADOOP_HOME} is set, should show "hadoop-home-defined" and not "download-hadoop"
- If ${HOME}/hadoop/hadoop-0.20.2_local is present, should show "hadoop-installed-in-home-dir" and not "download-hadoop"
- If we've run through a download before, should show "hadoop-in-target" and not "download-hadoop"
- If we've run through a download before and then done a `mvn clean`, should show "download-hadoop" again.
